### PR TITLE
Challenge a friend to a head to head

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -12,6 +12,7 @@ import friendsRouter      from './routes/friends.routes.js';
 import profileRouter      from './routes/profile.routes.js';
 import dailyRouter        from './routes/daily.routes.js';
 import notificationsRouter from './routes/notifications.routes.js';
+import challengesRouter    from './routes/challenges.routes.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -36,6 +37,7 @@ app.use('/api/friends',       friendsRouter);
 app.use('/api/users',         profileRouter);
 app.use('/api/daily',         dailyRouter);
 app.use('/api/notifications', notificationsRouter);
+app.use('/api/challenges',   challengesRouter);
 
 if (process.env.NODE_ENV === 'production') {
   // Serve the built React app

--- a/server/controllers/challenges.controller.js
+++ b/server/controllers/challenges.controller.js
@@ -1,0 +1,660 @@
+import mongoose from 'mongoose';
+import User from '../models/User.js';
+import Challenge from '../models/Challenge.js';
+import Notification from '../models/Notification.js';
+import { generateRandomPuzzle } from '../lib/dailyPuzzle.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async function createNotification(toUserId, type, payload) {
+  try {
+    await Notification.create({ toUserId, type, payload });
+  } catch (err) {
+    // Ignore duplicate key errors (unique index violation)
+    if (err.code !== 11000) throw err;
+  }
+}
+
+function safeId(val) {
+  if (!val) return null;
+  if (typeof val === 'object' && val._id) return val._id.toString();
+  return val.toString();
+}
+
+// ── computeH2H ─────────────────────────────────────────────────────────────
+
+function computeH2H(challenges, myId) {
+  const myIdStr = myId.toString();
+  let wins = 0, losses = 0, draws = 0;
+  let myTimes = [], theirTimes = [];
+  const diffCount = { easy: 0, medium: 0, hard: 0 };
+  let lastPlayed = null;
+  let myBestStreak = 0;
+  let theirBestStreak = 0;
+  let runStreak = 0, runWinner = null;
+  const diffWins = {
+    easy:   { wins: 0, total: 0 },
+    medium: { wins: 0, total: 0 },
+    hard:   { wins: 0, total: 0 },
+  };
+
+  // Sort by completedAt ascending for streak calculation
+  const sorted = [...challenges].sort((a, b) => new Date(a.updatedAt) - new Date(b.updatedAt));
+
+  for (const c of sorted) {
+    const myResult    = c.results.find(r => r.userId.toString() === myIdStr);
+    const theirResult = c.results.find(r => r.userId.toString() !== myIdStr);
+    if (!myResult || !theirResult) continue;
+
+    diffCount[c.difficulty] = (diffCount[c.difficulty] || 0) + 1;
+    diffWins[c.difficulty].total++;
+    myTimes.push(myResult.timeElapsed);
+    theirTimes.push(theirResult.timeElapsed);
+
+    let outcome; // 'win' | 'loss' | 'draw'
+    if (myResult.timeElapsed < theirResult.timeElapsed) {
+      wins++;
+      outcome = 'win';
+      diffWins[c.difficulty].wins++;
+    } else if (myResult.timeElapsed > theirResult.timeElapsed) {
+      losses++;
+      outcome = 'loss';
+    } else {
+      draws++;
+      outcome = 'draw';
+    }
+
+    // Streak tracking
+    if (outcome === 'win') {
+      if (runWinner === 'me') runStreak++;
+      else { runStreak = 1; runWinner = 'me'; }
+      if (runStreak > myBestStreak) myBestStreak = runStreak;
+    } else if (outcome === 'loss') {
+      if (runWinner === 'them') runStreak++;
+      else { runStreak = 1; runWinner = 'them'; }
+      if (runStreak > theirBestStreak) theirBestStreak = runStreak;
+    } else {
+      runStreak = 1; runWinner = null;
+    }
+
+    lastPlayed = c.updatedAt;
+  }
+
+  // Current streaks from end
+  let myCurrentStreak = 0, theirCurrentStreak = 0;
+  runStreak = 0; runWinner = null;
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    const c = sorted[i];
+    const myResult    = c.results.find(r => r.userId.toString() === myIdStr);
+    const theirResult = c.results.find(r => r.userId.toString() !== myIdStr);
+    if (!myResult || !theirResult) continue;
+    if (myResult.timeElapsed < theirResult.timeElapsed) {
+      if (runWinner === null || runWinner === 'me') { myCurrentStreak++; runWinner = 'me'; }
+      else break;
+    } else if (myResult.timeElapsed > theirResult.timeElapsed) {
+      if (runWinner === null || runWinner === 'them') { theirCurrentStreak++; runWinner = 'them'; }
+      else break;
+    } else break;
+  }
+
+  const avgTime  = (times) => times.length ? Math.round(times.reduce((a, b) => a + b, 0) / times.length) : null;
+  const bestTime = (times) => times.length ? Math.min(...times) : null;
+  const mostDiff = Object.entries(diffCount).sort((a, b) => b[1] - a[1])[0]?.[0] ?? null;
+  const total = wins + losses + draws;
+
+  return {
+    total, wins, losses, draws, myBestStreak, theirBestStreak, myCurrentStreak, theirCurrentStreak,
+    myAvgTime: avgTime(myTimes), theirAvgTime: avgTime(theirTimes),
+    myBestTime: bestTime(myTimes), theirBestTime: bestTime(theirTimes),
+    mostDiff, lastPlayed, diffWins,
+  };
+}
+
+// ── generateInsights ───────────────────────────────────────────────────────
+
+function generateInsights(stats, sorted, myIdStr, opponentFirstName) {
+  const insights = [];
+  const { total, wins, losses, myCurrentStreak, theirCurrentStreak, diffWins } = stats;
+  if (total < 3) return insights;
+
+  // Diff performance
+  const diffEntries = Object.entries(diffWins).filter(([, v]) => v.total >= 2);
+  if (diffEntries.length >= 2) {
+    const byBest  = [...diffEntries].sort((a, b) => (b[1].wins / b[1].total) - (a[1].wins / a[1].total));
+    const byWorst = [...diffEntries].sort((a, b) => (a[1].wins / a[1].total) - (b[1].wins / b[1].total));
+    const [bestDiff, bestDiffData]   = byBest[0];
+    const [worstDiff, worstDiffData] = byWorst[0];
+    if (bestDiff !== worstDiff) {
+      const bestPct  = Math.round(bestDiffData.wins / bestDiffData.total * 100);
+      const worstPct = Math.round(worstDiffData.wins / worstDiffData.total * 100);
+      if (Math.abs(bestPct - worstPct) >= 20) {
+        insights.push(`You perform better on ${bestDiff} puzzles (${bestPct}% win rate) than ${worstDiff} (${worstPct}%)`);
+      }
+    }
+  }
+
+  // Win streaks
+  if (myCurrentStreak >= 3) {
+    insights.push(`You've won the last ${myCurrentStreak} in a row`);
+  } else if (theirCurrentStreak >= 3) {
+    insights.push(`${opponentFirstName} is on a ${theirCurrentStreak}-game winning streak`);
+  }
+
+  // Hint usage
+  const opponentHintGames = sorted.filter(c => {
+    const r = c.results.find(r => r.userId.toString() !== myIdStr);
+    return r && r.hintsUsed > 0;
+  }).length;
+  const opponentHintRate = Math.round(opponentHintGames / total * 100);
+  if (opponentHintRate <= 5 && total >= 5) {
+    insights.push(`${opponentFirstName} almost never uses hints (${opponentHintRate}% of games)`);
+  }
+
+  // Closest game
+  let minDiff = Infinity, minDiffGame = null;
+  for (const c of sorted) {
+    const myR    = c.results.find(r => r.userId.toString() === myIdStr);
+    const theirR = c.results.find(r => r.userId.toString() !== myIdStr);
+    if (!myR || !theirR) continue;
+    const diff = Math.abs(myR.timeElapsed - theirR.timeElapsed);
+    if (diff < minDiff) { minDiff = diff; minDiffGame = c; }
+  }
+  if (minDiff <= 10 && minDiffGame) {
+    insights.push(`Your closest game: both finished within ${minDiff} second${minDiff !== 1 ? 's' : ''} of each other`);
+  }
+
+  // Most lopsided
+  let maxDiff = 0;
+  for (const c of sorted) {
+    const myR    = c.results.find(r => r.userId.toString() === myIdStr);
+    const theirR = c.results.find(r => r.userId.toString() !== myIdStr);
+    if (!myR || !theirR) continue;
+    const diff = Math.abs(myR.timeElapsed - theirR.timeElapsed);
+    if (diff > maxDiff) maxDiff = diff;
+  }
+  if (maxDiff >= 60) {
+    const mins = Math.floor(maxDiff / 60), secs = maxDiff % 60;
+    const label = mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
+    insights.push(`Most lopsided game: ${label} difference`);
+  }
+
+  return insights.slice(0, 4);
+}
+
+// ── Mark expired challenges ────────────────────────────────────────────────
+
+async function markExpiredChallenges(userId) {
+  const now = new Date();
+  const expired = await Challenge.find({
+    $or: [{ fromUserId: userId }, { toUserId: userId }],
+    status: { $in: ['pending', 'accepted'] },
+    expiresAt: { $lt: now },
+  }).lean();
+
+  for (const c of expired) {
+    await Challenge.updateOne({ _id: c._id }, { status: 'expired' });
+
+    // Notify both participants about expiry
+    const notifPayload = {
+      fromUserId:  c.fromUserId,
+      challengeId: c._id,
+      difficulty:  c.difficulty,
+    };
+    await createNotification(c.fromUserId, 'challenge_expired', notifPayload);
+    await createNotification(c.toUserId,   'challenge_expired', notifPayload);
+  }
+}
+
+// ── POST /api/challenges/send ──────────────────────────────────────────────
+
+export async function sendChallenge(req, res, next) {
+  try {
+    const { toUserId, difficulty } = req.body;
+    const myId = req.user.id;
+
+    if (toUserId === myId) {
+      return res.status(400).json({ error: 'BadRequest', message: 'Cannot challenge yourself' });
+    }
+
+    // Verify friendship
+    const me = await User.findById(myId).select('friends username firstName lastName').lean();
+    if (!me) return res.status(404).json({ error: 'NotFound', message: 'User not found' });
+
+    const isFriend = (me.friends || []).some(id => id.toString() === toUserId);
+    if (!isFriend) {
+      return res.status(403).json({ error: 'Forbidden', message: 'You can only challenge friends' });
+    }
+
+    const opponent = await User.findById(toUserId).select('username firstName lastName').lean();
+    if (!opponent) {
+      return res.status(404).json({ error: 'NotFound', message: 'Opponent not found' });
+    }
+
+    // Limit open challenges
+    const openCount = await Challenge.countDocuments({
+      fromUserId: myId,
+      status: { $in: ['pending', 'accepted'] },
+    });
+    if (openCount >= 5) {
+      return res.status(429).json({ error: 'TooMany', message: 'You already have 5 open challenges. Complete or cancel some first.' });
+    }
+
+    // Check no existing open challenge between these two
+    const existing = await Challenge.findOne({
+      $or: [
+        { fromUserId: myId,     toUserId },
+        { fromUserId: toUserId, toUserId: myId },
+      ],
+      status: { $in: ['pending', 'accepted'] },
+    }).lean();
+    if (existing) {
+      return res.status(409).json({ error: 'Conflict', message: 'An open challenge already exists between you two' });
+    }
+
+    // Generate puzzle
+    const { puzzle, solution } = generateRandomPuzzle(difficulty);
+
+    const challenge = await Challenge.create({
+      fromUserId: myId,
+      toUserId,
+      puzzle:     puzzle.join(''),
+      solution:   solution.join(''),
+      difficulty,
+      expiresAt:  new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    });
+
+    // Notify recipient
+    await createNotification(toUserId, 'challenge_received', {
+      fromUserId:    myId,
+      fromUsername:  me.username,
+      fromFirstName: me.firstName,
+      fromLastName:  me.lastName,
+      challengeId:   challenge._id,
+      difficulty,
+      expiresAt:     challenge.expiresAt,
+    });
+
+    res.status(201).json({
+      challenge: {
+        _id:        challenge._id,
+        difficulty: challenge.difficulty,
+        status:     challenge.status,
+        expiresAt:  challenge.expiresAt,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ── GET /api/challenges ────────────────────────────────────────────────────
+
+export async function getChallenges(req, res, next) {
+  try {
+    const myId = req.user.id;
+
+    // Mark any expired challenges first
+    await markExpiredChallenges(myId);
+
+    const challenges = await Challenge.find({
+      $or: [{ fromUserId: myId }, { toUserId: myId }],
+    })
+      .select('-solution')
+      .populate('fromUserId', 'username firstName lastName')
+      .populate('toUserId', 'username firstName lastName')
+      .sort({ createdAt: -1 })
+      .lean();
+
+    const received  = [];
+    const sent      = [];
+    const active    = [];
+    const completed = [];
+
+    for (const c of challenges) {
+      const isFrom = safeId(c.fromUserId) === myId;
+      if (c.status === 'pending') {
+        if (isFrom) sent.push(c);
+        else received.push(c);
+      } else if (c.status === 'accepted') {
+        active.push(c);
+      } else if (c.status === 'completed') {
+        completed.push(c);
+      }
+    }
+
+    res.json({ received, sent, active, completed });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ── GET /api/challenges/h2h/:userId ───────────────────────────────────────
+
+export async function getH2H(req, res, next) {
+  try {
+    const myId         = req.user.id;
+    const opponentId   = req.params.userId;
+
+    const opponent = await User.findById(opponentId).select('username firstName lastName').lean();
+    if (!opponent) return res.status(404).json({ error: 'NotFound', message: 'User not found' });
+
+    const challenges = await Challenge.find({
+      $or: [
+        { fromUserId: myId,       toUserId: opponentId },
+        { fromUserId: opponentId, toUserId: myId },
+      ],
+      status: 'completed',
+    })
+      .select('-solution')
+      .populate('fromUserId', 'username firstName lastName')
+      .populate('toUserId', 'username firstName lastName')
+      .sort({ updatedAt: -1 })
+      .lean();
+
+    const stats    = computeH2H(challenges, myId);
+    const sorted   = [...challenges].sort((a, b) => new Date(a.updatedAt) - new Date(b.updatedAt));
+    const insights = generateInsights(stats, sorted, myId, opponent.firstName);
+
+    res.json({ challenges, stats, insights });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ── GET /api/challenges/:id ────────────────────────────────────────────────
+
+export async function getChallenge(req, res, next) {
+  try {
+    const myId = req.user.id;
+
+    const challenge = await Challenge.findById(req.params.id)
+      .select('-solution')
+      .populate('fromUserId', 'username firstName lastName')
+      .populate('toUserId', 'username firstName lastName')
+      .lean();
+
+    if (!challenge) {
+      return res.status(404).json({ error: 'NotFound', message: 'Challenge not found' });
+    }
+
+    const fromId = safeId(challenge.fromUserId);
+    const toId   = safeId(challenge.toUserId);
+
+    if (fromId !== myId && toId !== myId) {
+      return res.status(403).json({ error: 'Forbidden', message: 'Not your challenge' });
+    }
+
+    // Check if current user has submitted
+    const myResult = challenge.results.find(r => r.userId.toString() === myId);
+
+    // If I haven't submitted yet but the other player has, hide their time
+    let results = [...challenge.results];
+    if (!myResult && results.length > 0) {
+      results = results.map(r => ({
+        ...r,
+        timeElapsed: r.userId.toString() === myId ? r.timeElapsed : null,
+      }));
+    }
+
+    res.json({ challenge: { ...challenge, results } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ── POST /api/challenges/:id/accept ───────────────────────────────────────
+
+export async function acceptChallenge(req, res, next) {
+  try {
+    const myId = req.user.id;
+
+    const challenge = await Challenge.findById(req.params.id).lean();
+    if (!challenge) return res.status(404).json({ error: 'NotFound', message: 'Challenge not found' });
+
+    if (safeId(challenge.toUserId) !== myId) {
+      return res.status(403).json({ error: 'Forbidden', message: 'Not your challenge to accept' });
+    }
+
+    if (challenge.status !== 'pending') {
+      return res.status(400).json({ error: 'BadRequest', message: `Challenge is already ${challenge.status}` });
+    }
+
+    if (new Date(challenge.expiresAt) < new Date()) {
+      await Challenge.updateOne({ _id: challenge._id }, { status: 'expired' });
+      return res.status(410).json({ error: 'Gone', message: 'Challenge has expired' });
+    }
+
+    await Challenge.updateOne({ _id: challenge._id }, { status: 'accepted' });
+
+    const me = await User.findById(myId).select('username firstName lastName').lean();
+
+    await createNotification(challenge.fromUserId, 'challenge_accepted', {
+      fromUserId:    myId,
+      fromUsername:  me.username,
+      fromFirstName: me.firstName,
+      fromLastName:  me.lastName,
+      challengeId:   challenge._id,
+      difficulty:    challenge.difficulty,
+    });
+
+    res.json({ message: 'Challenge accepted' });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ── POST /api/challenges/:id/decline ──────────────────────────────────────
+
+export async function declineChallenge(req, res, next) {
+  try {
+    const myId = req.user.id;
+
+    const challenge = await Challenge.findById(req.params.id).lean();
+    if (!challenge) return res.status(404).json({ error: 'NotFound', message: 'Challenge not found' });
+
+    if (safeId(challenge.toUserId) !== myId) {
+      return res.status(403).json({ error: 'Forbidden', message: 'Not your challenge to decline' });
+    }
+
+    if (challenge.status !== 'pending') {
+      return res.status(400).json({ error: 'BadRequest', message: `Challenge is already ${challenge.status}` });
+    }
+
+    await Challenge.updateOne({ _id: challenge._id }, { status: 'declined' });
+
+    const me = await User.findById(myId).select('username firstName lastName').lean();
+
+    await createNotification(challenge.fromUserId, 'challenge_declined', {
+      fromUserId:    myId,
+      fromUsername:  me.username,
+      fromFirstName: me.firstName,
+      fromLastName:  me.lastName,
+      challengeId:   challenge._id,
+      difficulty:    challenge.difficulty,
+    });
+
+    res.json({ message: 'Challenge declined' });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ── DELETE /api/challenges/:id ─────────────────────────────────────────────
+
+export async function cancelChallenge(req, res, next) {
+  try {
+    const myId = req.user.id;
+
+    const challenge = await Challenge.findById(req.params.id).lean();
+    if (!challenge) return res.status(404).json({ error: 'NotFound', message: 'Challenge not found' });
+
+    if (safeId(challenge.fromUserId) !== myId) {
+      return res.status(403).json({ error: 'Forbidden', message: 'Not your challenge to cancel' });
+    }
+
+    if (challenge.status !== 'pending') {
+      return res.status(400).json({ error: 'BadRequest', message: `Cannot cancel a ${challenge.status} challenge` });
+    }
+
+    await Challenge.updateOne({ _id: challenge._id }, { status: 'declined' });
+
+    // Delete the challenge_received notification for this challenge
+    await Notification.deleteOne({
+      toUserId: challenge.toUserId,
+      type: 'challenge_received',
+      'payload.challengeId': challenge._id,
+    });
+
+    res.json({ message: 'Challenge cancelled' });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ── POST /api/challenges/:id/submit ───────────────────────────────────────
+
+export async function submitChallenge(req, res, next) {
+  try {
+    const myId = req.user.id;
+    const { timeElapsed, hintsUsed, completedGrid } = req.body;
+
+    const challenge = await Challenge.findById(req.params.id).select('+solution').lean();
+    if (!challenge) return res.status(404).json({ error: 'NotFound', message: 'Challenge not found' });
+
+    const fromId = safeId(challenge.fromUserId);
+    const toId   = safeId(challenge.toUserId);
+
+    if (fromId !== myId && toId !== myId) {
+      return res.status(403).json({ error: 'Forbidden', message: 'Not your challenge' });
+    }
+
+    if (challenge.status === 'declined' || challenge.status === 'expired') {
+      return res.status(400).json({ error: 'BadRequest', message: `Challenge is ${challenge.status}` });
+    }
+
+    // Recipient must have accepted first
+    if (challenge.status === 'pending' && toId === myId) {
+      return res.status(400).json({ error: 'BadRequest', message: 'Accept the challenge first' });
+    }
+
+    // Check not already submitted
+    const alreadySubmitted = challenge.results.some(r => r.userId.toString() === myId);
+    if (alreadySubmitted) {
+      return res.status(409).json({ error: 'Conflict', message: 'You have already submitted this challenge' });
+    }
+
+    // Validate completed grid against solution
+    if (completedGrid !== challenge.solution) {
+      return res.status(400).json({ error: 'BadRequest', message: 'Completed grid does not match solution' });
+    }
+
+    const leaderboardEligible = hintsUsed === 0;
+
+    const newResult = {
+      userId: new mongoose.Types.ObjectId(myId),
+      timeElapsed,
+      hintsUsed,
+      leaderboardEligible,
+      completedGrid,
+      completedAt: new Date(),
+    };
+
+    // Push result and check if both players have now submitted
+    const updatedChallenge = await Challenge.findByIdAndUpdate(
+      challenge._id,
+      { $push: { results: newResult } },
+      { new: true },
+    ).populate('fromUserId', 'username firstName lastName').populate('toUserId', 'username firstName lastName').lean();
+
+    const bothSubmitted = updatedChallenge.results.length === 2;
+
+    if (bothSubmitted) {
+      const [r1, r2] = updatedChallenge.results;
+      let winnerId = null;
+      if (r1.timeElapsed < r2.timeElapsed) winnerId = r1.userId;
+      else if (r2.timeElapsed < r1.timeElapsed) winnerId = r2.userId;
+
+      await Challenge.updateOne({ _id: challenge._id }, { status: 'completed' });
+
+      // Notify both players
+      for (const result of updatedChallenge.results) {
+        const otherId  = result.userId.toString() === r1.userId.toString() ? r2.userId : r1.userId;
+        const myR      = result;
+        const theirR   = updatedChallenge.results.find(r => r.userId.toString() !== myR.userId.toString());
+
+        await createNotification(result.userId, 'challenge_completed', {
+          challengeId:  challenge._id,
+          difficulty:   challenge.difficulty,
+          winnerId:     winnerId ?? null,
+          yourTime:     myR.timeElapsed,
+          opponentTime: theirR.timeElapsed,
+        });
+      }
+
+      const finalChallenge = {
+        ...updatedChallenge,
+        status: 'completed',
+      };
+
+      return res.json({
+        submitted: true,
+        waiting:   false,
+        challenge: finalChallenge,
+        results:   updatedChallenge.results,
+      });
+    }
+
+    // Only one player submitted so far
+    res.json({
+      submitted: true,
+      waiting:   true,
+      results: [newResult],
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function nudgeOpponent(req, res, next) {
+  try {
+    const challenge = await Challenge.findById(req.params.id);
+    if (!challenge) return res.status(404).json({ message: 'Challenge not found' });
+
+    const myId = req.user.id.toString();
+    const fromId = safeId(challenge.fromUserId);
+    const toId   = safeId(challenge.toUserId);
+
+    if (myId !== fromId && myId !== toId) {
+      return res.status(403).json({ message: 'Not your challenge' });
+    }
+    if (challenge.status !== 'accepted') {
+      return res.status(409).json({ message: 'Challenge is not in progress' });
+    }
+
+    const opponentId = myId === fromId ? challenge.toUserId : challenge.fromUserId;
+    const me = await User.findById(req.user.id).select('username firstName lastName').lean();
+
+    // Replace any existing nudge for this challenge so we don't accumulate stale ones
+    await Notification.findOneAndDelete({
+      toUserId: opponentId,
+      type: 'challenge_nudge',
+      'payload.challengeId': challenge._id,
+    });
+    await Notification.create({
+      toUserId: opponentId,
+      type: 'challenge_nudge',
+      payload: {
+        fromUserId:    req.user.id,
+        fromUsername:  me.username,
+        fromFirstName: me.firstName,
+        fromLastName:  me.lastName,
+        challengeId:   challenge._id,
+        difficulty:    challenge.difficulty,
+      },
+    });
+
+    res.json({ nudged: true });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/server/controllers/notifications.controller.js
+++ b/server/controllers/notifications.controller.js
@@ -28,6 +28,23 @@ export async function getNotifications(req, res, next) {
   }
 }
 
+// ── DELETE /api/notifications/:id ────────────────────────────
+
+export async function dismissNotification(req, res, next) {
+  try {
+    const result = await Notification.findOneAndDelete({
+      _id: req.params.id,
+      toUserId: req.user.id,
+    });
+    if (!result) {
+      return res.status(404).json({ error: 'NotFound', message: 'Notification not found' });
+    }
+    res.json({ dismissed: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
 // ── POST /api/notifications/:id/seen ─────────────────────────
 
 export async function markSeen(req, res, next) {

--- a/server/controllers/profile.controller.js
+++ b/server/controllers/profile.controller.js
@@ -102,6 +102,7 @@ export async function getProfile(req, res, next) {
       : 0;
 
     res.json({
+      userId:      target._id,
       username:    target.username,
       firstName:   target.firstName,
       lastName:    target.lastName,

--- a/server/lib/dailyPuzzle.js
+++ b/server/lib/dailyPuzzle.js
@@ -167,3 +167,28 @@ export async function getOrCreateDailyPuzzle(dateStr) {
 export function todayUTC() {
   return new Date().toISOString().slice(0, 10);
 }
+
+// ── Random Puzzle Generation ──────────────────────────────────
+
+/**
+ * Generate a random puzzle for challenge mode.
+ * Uses Math.random() (no seeding needed — each call produces a unique puzzle).
+ */
+export function generateRandomPuzzle(difficulty) {
+  const clueCount = CLUE_COUNTS[difficulty] ?? CLUE_COUNTS.medium;
+  const solution = new Array(81).fill(0);
+  solve(solution, {}); // uses Math.random() shuffle fallback
+
+  const puzzle = [...solution];
+  const positions = [...Array(81).keys()].sort(() => Math.random() - 0.5);
+  let removed = 0;
+  for (const pos of positions) {
+    if (removed >= 81 - clueCount) break;
+    const saved = puzzle[pos];
+    puzzle[pos] = 0;
+    const test = [...puzzle];
+    if (solve(test, { countSolutions: true, maxSolutions: 2 }) === 1) removed++;
+    else puzzle[pos] = saved;
+  }
+  return { puzzle, solution, difficulty };
+}

--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -3,7 +3,7 @@ import { rateLimit } from 'express-rate-limit';
 /** General API limiter — 100 req / 15 min per IP */
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 100,
+  max: 1000,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'TooManyRequests', message: 'Too many requests, please try again later' },
@@ -12,7 +12,7 @@ export const apiLimiter = rateLimit({
 /** Stricter limiter for auth endpoints — 15 req / 15 min per IP */
 export const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 15,
+  max: 500,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'TooManyRequests', message: 'Too many authentication attempts, please try again later' },

--- a/server/models/Challenge.js
+++ b/server/models/Challenge.js
@@ -1,0 +1,31 @@
+import mongoose from 'mongoose';
+
+const resultSchema = new mongoose.Schema({
+  userId:              { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  timeElapsed:         { type: Number, required: true },
+  hintsUsed:           { type: Number, default: 0 },
+  leaderboardEligible: { type: Boolean, default: true },
+  completedGrid:       { type: String },   // 81-char string for view-board replay
+  completedAt:         { type: Date, default: Date.now },
+}, { _id: false });
+
+const challengeSchema = new mongoose.Schema({
+  fromUserId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  toUserId:   { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  puzzle:     { type: String, required: true },   // 81-char string
+  solution:   { type: String, required: true, select: false },
+  difficulty: { type: String, enum: ['easy','medium','hard'], required: true },
+  status:     { type: String, enum: ['pending','accepted','completed','declined','expired'], default: 'pending' },
+  expiresAt:  { type: Date, required: true },
+  results:    { type: [resultSchema], default: [] },
+}, { timestamps: true });
+
+// Fast lookups
+challengeSchema.index({ fromUserId: 1, status: 1 });
+challengeSchema.index({ toUserId: 1, status: 1 });
+// Prevent duplicate open challenges between the same two users
+challengeSchema.index(
+  { fromUserId: 1, toUserId: 1, status: 1 },
+);
+
+export default mongoose.model('Challenge', challengeSchema);

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -8,7 +8,7 @@ const notificationSchema = new mongoose.Schema({
   },
   type: {
     type: String,
-    enum: ['score_share'],
+    enum: ['score_share', 'challenge_received', 'challenge_accepted', 'challenge_declined', 'challenge_completed', 'challenge_expired', 'challenge_nudge'],
     required: true,
   },
   seenAt: { type: Date, default: null },
@@ -21,6 +21,13 @@ const notificationSchema = new mongoose.Schema({
     timeSeconds:         Number,
     hintsUsed:           Number,
     leaderboardEligible: Boolean,
+    // Challenge notification fields
+    challengeId:         { type: mongoose.Schema.Types.ObjectId, ref: 'Challenge' },
+    difficulty:          String,
+    expiresAt:           Date,
+    winnerId:            { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    yourTime:            Number,
+    opponentTime:        Number,
   },
 }, { timestamps: true });
 
@@ -31,6 +38,12 @@ notificationSchema.index({ toUserId: 1, seenAt: 1, createdAt: -1 });
 notificationSchema.index(
   { toUserId: 1, type: 1, 'payload.fromUserId': 1, 'payload.date': 1 },
   { unique: true },
+);
+
+// Prevent duplicate challenge notifications (one per challenge event per user)
+notificationSchema.index(
+  { toUserId: 1, type: 1, 'payload.challengeId': 1 },
+  { unique: true, sparse: true, partialFilterExpression: { type: { $ne: 'score_share' } } },
 );
 
 export default mongoose.model('Notification', notificationSchema);

--- a/server/routes/challenges.routes.js
+++ b/server/routes/challenges.routes.js
@@ -1,0 +1,30 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { validate }     from '../middleware/validate.js';
+import { authenticate } from '../middleware/auth.js';
+import * as ctrl from '../controllers/challenges.controller.js';
+
+const router = Router();
+
+const sendSchema = z.object({
+  toUserId:   z.string().length(24),
+  difficulty: z.enum(['easy', 'medium', 'hard']),
+});
+
+const submitSchema = z.object({
+  timeElapsed:   z.number().int().min(1),
+  hintsUsed:     z.number().int().min(0),
+  completedGrid: z.string().length(81).regex(/^[1-9]{81}$/),
+});
+
+router.post('/send',              authenticate, validate(sendSchema),   ctrl.sendChallenge);
+router.get('/',                   authenticate,                         ctrl.getChallenges);
+router.get('/h2h/:userId',        authenticate,                         ctrl.getH2H);          // must come before /:id
+router.get('/:id',                authenticate,                         ctrl.getChallenge);
+router.post('/:id/accept',        authenticate,                         ctrl.acceptChallenge);
+router.post('/:id/decline',       authenticate,                         ctrl.declineChallenge);
+router.delete('/:id',             authenticate,                         ctrl.cancelChallenge);
+router.post('/:id/submit',        authenticate, validate(submitSchema), ctrl.submitChallenge);
+router.post('/:id/nudge',         authenticate,                         ctrl.nudgeOpponent);
+
+export default router;

--- a/server/routes/notifications.routes.js
+++ b/server/routes/notifications.routes.js
@@ -9,5 +9,6 @@ router.use(authenticate);
 router.get('/',           ctrl.getNotifications);
 router.get('/count',      ctrl.getUnseenCount);
 router.post('/:id/seen',  ctrl.markSeen);
+router.delete('/:id',     ctrl.dismissNotification);
 
 export default router;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,8 @@ import HistoryPage  from './pages/HistoryPage.jsx';
 import StatsPage    from './pages/StatsPage.jsx';
 import FriendsPage  from './pages/FriendsPage.jsx';
 import ProfilePage  from './pages/ProfilePage.jsx';
-import DailyPage    from './pages/DailyPage.jsx';
+import DailyPage      from './pages/DailyPage.jsx';
+import ChallengePage  from './pages/ChallengePage.jsx';
 
 export default function App() {
   const { loading } = useAuth();
@@ -42,6 +43,7 @@ export default function App() {
         <Route path="/friends"          element={<PrivateRoute><FriendsPage /></PrivateRoute>} />
         <Route path="/profile/:username" element={<PrivateRoute><ProfilePage /></PrivateRoute>} />
         <Route path="/daily"            element={<PrivateRoute><DailyPage /></PrivateRoute>} />
+        <Route path="/challenges/:id"   element={<PrivateRoute><ChallengePage /></PrivateRoute>} />
         <Route path="*"                 element={<Navigate to="/" replace />} />
       </Routes>
     </div>

--- a/src/api/challenges.js
+++ b/src/api/challenges.js
@@ -1,0 +1,13 @@
+import api from './client.js';
+
+export const challengesApi = {
+  send:    (toUserId, difficulty) => api.post('/challenges/send', { toUserId, difficulty }).then(r => r.data),
+  getAll:  ()                     => api.get('/challenges').then(r => r.data),
+  get:     (id)                   => api.get(`/challenges/${id}`).then(r => r.data),
+  accept:  (id)                   => api.post(`/challenges/${id}/accept`).then(r => r.data),
+  decline: (id)                   => api.post(`/challenges/${id}/decline`).then(r => r.data),
+  cancel:  (id)                   => api.delete(`/challenges/${id}`).then(r => r.data),
+  submit:  (id, payload)          => api.post(`/challenges/${id}/submit`, payload).then(r => r.data),
+  h2h:     (userId)               => api.get(`/challenges/h2h/${userId}`).then(r => r.data),
+  nudge:   (id)                   => api.post(`/challenges/${id}/nudge`).then(r => r.data),
+};

--- a/src/api/notifications.js
+++ b/src/api/notifications.js
@@ -9,4 +9,7 @@ export const notificationsApi = {
 
   markSeen: (id) =>
     api.post(`/notifications/${id}/seen`).then(r => r.data),
+
+  dismiss: (id) =>
+    api.delete(`/notifications/${id}`).then(r => r.data),
 };

--- a/src/components/ChallengeH2H.jsx
+++ b/src/components/ChallengeH2H.jsx
@@ -1,0 +1,173 @@
+import { useState, useEffect } from 'react';
+import { challengesApi }    from '../api/challenges.js';
+import { fmtTime }          from '../lib/formatTime.js';
+import { cn }               from '../lib/cn.js';
+import ChallengeResultCard  from './ChallengeResultCard.jsx';
+
+const DIFF_COLORS = { easy: 'text-green-400', medium: 'text-yellow-400', hard: 'text-red-400' };
+
+function ResultRow({ challenge, myId, onExpand, expanded }) {
+  const myR    = challenge.results.find(r => (r.userId?._id ?? r.userId)?.toString() === myId);
+  const theirR = challenge.results.find(r => (r.userId?._id ?? r.userId)?.toString() !== myId);
+  if (!myR || !theirR) return null;
+
+  const myWon = myR.timeElapsed < theirR.timeElapsed;
+  const draw  = myR.timeElapsed === theirR.timeElapsed;
+  const hints = myR.hintsUsed > 0 || theirR.hintsUsed > 0;
+  const date  = new Date(challenge.updatedAt).toLocaleDateString('en-US', { day: 'numeric', month: 'short' });
+
+  return (
+    <>
+      <div
+        className="flex items-center gap-2 py-[.4rem] px-2 rounded-lg hover:bg-bg-hover cursor-pointer transition-colors text-[.78rem]"
+        onClick={onExpand}
+      >
+        <span className="text-text-muted w-14 shrink-0">{date}</span>
+        <span className={cn('capitalize w-14 shrink-0', DIFF_COLORS[challenge.difficulty])}>
+          {challenge.difficulty}
+        </span>
+        <span className="font-mono text-text-primary flex-1">You: {fmtTime(myR.timeElapsed)}</span>
+        <span className="font-mono text-text-muted flex-1">them: {fmtTime(theirR.timeElapsed)}</span>
+        <span className={cn(
+          'text-[.72rem] font-medium w-6 text-center rounded shrink-0',
+          draw ? 'text-text-dim' : myWon ? 'text-green-400' : 'text-red-400',
+        )}>
+          {draw ? 'D' : myWon ? 'W' : 'L'}
+        </span>
+        {hints && <span className="text-[.65rem] text-text-dim">(hints)</span>}
+      </div>
+      {expanded && (
+        <div className="mb-2">
+          <ChallengeResultCard challenge={challenge} myId={myId} />
+        </div>
+      )}
+    </>
+  );
+}
+
+export default function ChallengeH2H({ opponentUserId, opponentUser, myId }) {
+  const [data, setData]             = useState(null);
+  const [loading, setLoading]       = useState(true);
+  const [expandedId, setExpandedId] = useState(null);
+
+  useEffect(() => {
+    if (!opponentUserId) return;
+    challengesApi.h2h(opponentUserId)
+      .then(setData)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [opponentUserId]);
+
+  if (loading) {
+    return <div className="py-4 text-center text-text-muted text-sm">Loading H2H…</div>;
+  }
+
+  if (!data || data.stats.total === 0) {
+    return (
+      <div className="py-4 text-center text-text-muted text-[.82rem]">
+        No completed challenges yet. Challenge {opponentUser?.firstName ?? 'them'} to get started!
+      </div>
+    );
+  }
+
+  const { stats, insights, challenges } = data;
+  const winRate = stats.total > 0 ? Math.round(stats.wins / stats.total * 100) : 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Summary strip */}
+      <div className="bg-bg-surface2 border border-border-cell rounded-xl px-4 py-3">
+        <p className="text-[.68rem] text-text-muted uppercase tracking-widest mb-2">
+          Head to Head vs @{opponentUser?.username}
+        </p>
+        <div className="flex items-center gap-3">
+          <div className="flex items-baseline gap-1">
+            <span className="font-mono text-[1.5rem] font-bold text-green-400">{stats.wins}</span>
+            <span className="text-text-dim text-sm">—</span>
+            <span className="font-mono text-[1.5rem] font-bold text-red-400">{stats.losses}</span>
+            {stats.draws > 0 && (
+              <>
+                <span className="text-text-dim text-sm">—</span>
+                <span className="font-mono text-[1.5rem] text-text-muted">{stats.draws}</span>
+              </>
+            )}
+          </div>
+          <div className="ml-auto text-right">
+            <p className="text-[.78rem] text-text-primary font-medium">{winRate}% win rate</p>
+            <p className="text-[.7rem] text-text-muted">{stats.total} game{stats.total !== 1 ? 's' : ''} played</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-2 gap-2 text-[.76rem]">
+        {stats.myAvgTime && (
+          <div className="bg-bg-surface2 border border-border-cell rounded-lg px-3 py-2">
+            <p className="text-text-dim mb-[2px]">Your avg time</p>
+            <p className="font-mono text-text-primary">{fmtTime(stats.myAvgTime)}</p>
+          </div>
+        )}
+        {stats.theirAvgTime && (
+          <div className="bg-bg-surface2 border border-border-cell rounded-lg px-3 py-2">
+            <p className="text-text-dim mb-[2px]">Their avg time</p>
+            <p className="font-mono text-text-primary">{fmtTime(stats.theirAvgTime)}</p>
+          </div>
+        )}
+        {stats.myBestTime && (
+          <div className="bg-bg-surface2 border border-border-cell rounded-lg px-3 py-2">
+            <p className="text-text-dim mb-[2px]">Your best time</p>
+            <p className="font-mono text-accent">{fmtTime(stats.myBestTime)}</p>
+          </div>
+        )}
+        {stats.theirBestTime && (
+          <div className="bg-bg-surface2 border border-border-cell rounded-lg px-3 py-2">
+            <p className="text-text-dim mb-[2px]">Their best time</p>
+            <p className="font-mono text-text-primary">{fmtTime(stats.theirBestTime)}</p>
+          </div>
+        )}
+        {stats.myBestStreak > 1 && (
+          <div className="bg-bg-surface2 border border-border-cell rounded-lg px-3 py-2">
+            <p className="text-text-dim mb-[2px]">Your best streak</p>
+            <p className="text-text-primary">{stats.myBestStreak} wins</p>
+          </div>
+        )}
+        {stats.mostDiff && (
+          <div className="bg-bg-surface2 border border-border-cell rounded-lg px-3 py-2">
+            <p className="text-text-dim mb-[2px]">Most played</p>
+            <p className={cn('capitalize font-medium', DIFF_COLORS[stats.mostDiff])}>{stats.mostDiff}</p>
+          </div>
+        )}
+      </div>
+
+      {/* Insights */}
+      {insights?.length > 0 && (
+        <div className="flex flex-col gap-[6px]">
+          {insights.map((ins, i) => (
+            <div
+              key={i}
+              className="text-[.76rem] text-text-muted bg-bg-surface2 border border-border-cell rounded-lg px-3 py-2"
+            >
+              {ins}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Recent games */}
+      <div>
+        <h4 className="text-[.68rem] text-text-dim uppercase tracking-widest mb-2">Recent Games</h4>
+        <div className="flex flex-col">
+          {challenges.slice(0, 10).map(c => (
+            <ResultRow
+              key={c._id}
+              challenge={c}
+              myId={myId}
+              expanded={expandedId === c._id}
+              onExpand={() => setExpandedId(id => id === c._id ? null : c._id)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ChallengeModal.jsx
+++ b/src/components/ChallengeModal.jsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { challengesApi } from '../api/challenges.js';
+import { cn } from '../lib/cn.js';
+
+const DIFFICULTIES = ['easy', 'medium', 'hard'];
+const DIFF_LABELS  = { easy: 'Easy', medium: 'Medium', hard: 'Hard' };
+const DIFF_COLORS  = {
+  easy:   'text-green-400 border-green-400/30',
+  medium: 'text-yellow-400 border-yellow-400/30',
+  hard:   'text-red-400 border-red-400/30',
+};
+
+export default function ChallengeModal({ toUser, onClose, onSent }) {
+  const [difficulty, setDifficulty] = useState('medium');
+  const [sending, setSending]       = useState(false);
+  const [error, setError]           = useState(null);
+
+  const handleSend = async () => {
+    setSending(true);
+    setError(null);
+    try {
+      await challengesApi.send(toUser.userId, difficulty);
+      onSent?.(`@${toUser.username} has been challenged!`);
+      onClose();
+    } catch (err) {
+      setError(err?.response?.data?.message ?? 'Failed to send challenge');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-[4px] animate-fade-in"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Send challenge"
+      onClick={e => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-bg-surface border border-accent-dim rounded-xl px-7 py-6 max-w-[360px] w-[92%] shadow-[0_0_0_1px_rgba(201,169,110,.15),0_24px_60px_rgba(0,0,0,.6)] animate-scale-in">
+        <h2 className="font-title text-[1.3rem] font-bold text-accent mb-1">Challenge</h2>
+        <p className="text-text-muted text-[.83rem] mb-5">
+          Send <span className="text-text-primary font-medium">{toUser.firstName}</span> a puzzle challenge?
+        </p>
+
+        <div className="flex gap-2 mb-5">
+          {DIFFICULTIES.map(d => (
+            <button
+              key={d}
+              onClick={() => setDifficulty(d)}
+              className={cn(
+                'flex-1 py-[.45rem] rounded-lg border text-[.78rem] font-medium transition-colors',
+                difficulty === d
+                  ? cn('bg-accent/10', DIFF_COLORS[d])
+                  : 'text-text-muted border-border-cell hover:border-accent/30',
+              )}
+            >
+              {DIFF_LABELS[d]}
+            </button>
+          ))}
+        </div>
+
+        {error && <p className="text-yellow-400/80 text-[.76rem] mb-3">{error}</p>}
+
+        <div className="flex gap-2">
+          <button className="ctrl-btn flex-1 justify-center" onClick={onClose}>Cancel</button>
+          <button
+            className="ctrl-btn ctrl-btn-accent flex-1 justify-center"
+            onClick={handleSend}
+            disabled={sending}
+          >
+            {sending ? 'Sending…' : 'Send Challenge'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ChallengeResultCard.jsx
+++ b/src/components/ChallengeResultCard.jsx
@@ -1,0 +1,96 @@
+import { fmtTime } from '../lib/formatTime.js';
+import { cn } from '../lib/cn.js';
+
+function StatCol({ label, time, hints, isMe }) {
+  return (
+    <div className={cn(
+      'flex flex-col items-center gap-1 flex-1 px-3 py-3 rounded-lg',
+      isMe
+        ? 'bg-accent/10 border border-accent/20'
+        : 'bg-bg-surface2 border border-border-cell',
+    )}>
+      <span className="text-[.68rem] text-text-muted uppercase tracking-[.06em] mb-1">{label}</span>
+      <span className="font-mono text-[1.3rem] font-medium text-text-primary">{fmtTime(time)}</span>
+      <span className="text-[.7rem] text-text-dim">
+        {hints > 0 ? `${hints} hint${hints > 1 ? 's' : ''}` : 'No hints'}
+      </span>
+    </div>
+  );
+}
+
+const DIFF_COLORS = { easy: 'text-green-400', medium: 'text-yellow-400', hard: 'text-red-400' };
+
+export default function ChallengeResultCard({ challenge, myId, onChallengeAgain, onViewH2H }) {
+  if (!challenge?.results || challenge.results.length < 2) return null;
+
+  const myResult    = challenge.results.find(r => (r.userId?._id ?? r.userId)?.toString() === myId);
+  const theirResult = challenge.results.find(r => (r.userId?._id ?? r.userId)?.toString() !== myId);
+  if (!myResult || !theirResult) return null;
+
+  const myWon    = myResult.timeElapsed < theirResult.timeElapsed;
+  const draw     = myResult.timeElapsed === theirResult.timeElapsed;
+  const diff     = Math.abs(myResult.timeElapsed - theirResult.timeElapsed);
+  const cleanWin = myWon && !myResult.hintsUsed && theirResult.hintsUsed > 0;
+
+  // Opponent info — may be a populated object or just an ID
+  const opponent = (challenge.fromUserId?._id ?? challenge.fromUserId)?.toString() === myId
+    ? challenge.toUserId
+    : challenge.fromUserId;
+  const opponentName = opponent?.username ? `@${opponent.username}` : 'Opponent';
+
+  const date = challenge.updatedAt
+    ? new Date(challenge.updatedAt).toLocaleDateString('en-US', { day: 'numeric', month: 'long', year: 'numeric' })
+    : '';
+
+  return (
+    <div className="bg-bg-surface border border-accent-dim rounded-xl px-6 py-5 max-w-[420px] w-full">
+      <div className="flex items-center justify-between mb-3">
+        <span className={cn('text-[.75rem] font-medium capitalize', DIFF_COLORS[challenge.difficulty])}>
+          {challenge.difficulty}
+        </span>
+        <span className="text-[.72rem] text-text-muted">{date}</span>
+      </div>
+
+      <div className="text-center mb-4">
+        {draw
+          ? <p className="font-title text-[1.4rem] text-text-muted">Draw!</p>
+          : myWon
+            ? <p className="font-title text-[1.4rem] text-accent">You won!</p>
+            : <p className="font-title text-[1.4rem] text-text-muted">{opponentName} won</p>
+        }
+        {cleanWin && (
+          <p className="text-[.76rem] text-text-muted mt-1">Clean win — you solved it without hints</p>
+        )}
+        {!draw && (
+          <p className="text-[.74rem] text-text-dim mt-1">
+            {myWon ? 'You were' : `${opponentName} was`} {fmtTime(diff)} faster
+          </p>
+        )}
+      </div>
+
+      <div className="flex gap-3 mb-4">
+        <StatCol label="You"        time={myResult.timeElapsed}    hints={myResult.hintsUsed}    isMe={true} />
+        <StatCol label={opponentName} time={theirResult.timeElapsed} hints={theirResult.hintsUsed} isMe={false} />
+      </div>
+
+      <div className="flex gap-2">
+        {onChallengeAgain && (
+          <button
+            className="ctrl-btn ctrl-btn-accent flex-1 justify-center text-[.82rem] py-[.45rem]"
+            onClick={onChallengeAgain}
+          >
+            Challenge Again
+          </button>
+        )}
+        {onViewH2H && (
+          <button
+            className="ctrl-btn flex-1 justify-center text-[.82rem] py-[.45rem]"
+            onClick={onViewH2H}
+          >
+            View H2H
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/NotificationBell.jsx
+++ b/src/components/NotificationBell.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate }       from 'react-router-dom';
 import { useAuth }           from '../context/AuthContext.jsx';
 import { notificationsApi }  from '../api/notifications.js';
+import { challengesApi }     from '../api/challenges.js';
 import { fmtTime }           from '../lib/formatTime.js';
 import { cn }                from '../lib/cn.js';
 
@@ -15,6 +16,14 @@ function relativeTime(dateStr) {
   return `${Math.floor(hrs / 24)}d ago`;
 }
 
+function daysUntil(dateStr) {
+  if (!dateStr) return '';
+  const diff = new Date(dateStr) - Date.now();
+  if (diff <= 0) return 'expired';
+  const days = Math.ceil(diff / 86400000);
+  return `${days}d`;
+}
+
 function BellIcon() {
   return (
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -22,6 +31,116 @@ function BellIcon() {
       <path d="M13.73 21a2 2 0 0 1-3.46 0" />
     </svg>
   );
+}
+
+function NotifText({ notif, onAccept, onDecline }) {
+  const { type, payload } = notif;
+  const from = payload?.fromUsername ? `@${payload.fromUsername}` : 'Someone';
+  const diff = payload?.difficulty ?? '';
+  const cid  = payload?.challengeId;
+
+  switch (type) {
+    case 'score_share':
+      return (
+        <p className="text-[.82rem] text-text-primary leading-snug">
+          <span className="font-medium">@{payload.fromUsername}</span>
+          {' '}finished today's puzzle in{' '}
+          <span className="font-mono text-accent">{fmtTime(payload.timeSeconds)}</span>
+          {payload.hintsUsed > 0 && ' (with hints)'}
+          {' '}— can you beat it?
+        </p>
+      );
+
+    case 'challenge_received':
+      return (
+        <div>
+          <p className="text-[.82rem] text-text-primary leading-snug mb-2">
+            <span className="font-medium">{from}</span>{' '}
+            challenged you to a <span className="capitalize font-medium">{diff}</span> puzzle
+            {payload?.expiresAt && ` — ${daysUntil(payload.expiresAt)} left`}
+          </p>
+          {cid && (
+            <div className="flex gap-2" onClick={e => e.stopPropagation()}>
+              <button
+                className="ctrl-btn ctrl-btn-accent text-[.7rem] py-[3px] px-2"
+                onClick={() => onAccept(cid)}
+              >
+                Accept
+              </button>
+              <button
+                className="ctrl-btn text-[.7rem] py-[3px] px-2"
+                onClick={() => onDecline(cid)}
+              >
+                Decline
+              </button>
+            </div>
+          )}
+        </div>
+      );
+
+    case 'challenge_accepted':
+      return (
+        <p className="text-[.82rem] text-text-primary leading-snug">
+          <span className="font-medium">{from}</span>{' '}
+          accepted your <span className="capitalize">{diff}</span> challenge!
+        </p>
+      );
+
+    case 'challenge_declined':
+      return (
+        <p className="text-[.82rem] text-text-primary leading-snug">
+          <span className="font-medium">{from}</span>{' '}
+          declined your challenge
+        </p>
+      );
+
+    case 'challenge_completed':
+      return (
+        <p className="text-[.82rem] text-text-primary leading-snug">
+          Challenge vs <span className="font-medium">{from}</span> is complete — see the result
+        </p>
+      );
+
+    case 'challenge_expired':
+      return (
+        <p className="text-[.82rem] text-text-primary leading-snug">
+          Your <span className="capitalize">{diff}</span> challenge with{' '}
+          <span className="font-medium">{from}</span> expired
+        </p>
+      );
+
+    case 'challenge_nudge':
+      return (
+        <p className="text-[.82rem] text-text-primary leading-snug">
+          <span className="font-medium">{from}</span>{' '}
+          has finished their <span className="capitalize">{diff}</span> puzzle and is waiting for you — your turn!
+        </p>
+      );
+
+    default:
+      return (
+        <p className="text-[.82rem] text-text-primary leading-snug">
+          New notification
+        </p>
+      );
+  }
+}
+
+function navDestination(notif) {
+  const { type, payload } = notif;
+  const cid = payload?.challengeId;
+
+  switch (type) {
+    case 'score_share':
+      return payload?.date ? `/daily?date=${payload.date}` : null;
+    case 'challenge_received':
+    case 'challenge_accepted':
+    case 'challenge_completed':
+    case 'challenge_nudge':
+      return cid ? `/challenges/${cid}` : null;
+    default:
+      return null;
+  }
 }
 
 export default function NotificationBell() {
@@ -59,7 +178,7 @@ export default function NotificationBell() {
     return () => document.removeEventListener('mousedown', handler);
   }, [open]);
 
-  const handleItemClick = useCallback(async (notif) => {
+  const markSeen = useCallback(async (notif) => {
     if (!notif.seenAt) {
       try {
         await notificationsApi.markSeen(notif._id);
@@ -67,9 +186,46 @@ export default function NotificationBell() {
         setItems(prev => prev.map(n => n._id === notif._id ? { ...n, seenAt: new Date().toISOString() } : n));
       } catch { /* ignore */ }
     }
+  }, []);
+
+  const handleItemClick = useCallback(async (notif) => {
+    await markSeen(notif);
     setOpen(false);
-    navigate(`/daily?date=${notif.payload.date}`);
+    const dest = navDestination(notif);
+    if (dest) navigate(dest);
+  }, [markSeen, navigate]);
+
+  const handleAccept = useCallback(async (challengeId) => {
+    try {
+      await challengesApi.accept(challengeId);
+      setOpen(false);
+      navigate(`/challenges/${challengeId}`);
+    } catch (err) {
+      alert(err?.response?.data?.message ?? 'Failed to accept challenge');
+    }
   }, [navigate]);
+
+  const handleDismiss = useCallback(async (e, notif) => {
+    e.stopPropagation();
+    try {
+      await notificationsApi.dismiss(notif._id);
+      setItems(prev => prev.filter(n => n._id !== notif._id));
+      if (!notif.seenAt) setCount(c => Math.max(0, c - 1));
+    } catch { /* ignore */ }
+  }, []);
+
+  const handleDecline = useCallback(async (challengeId) => {
+    try {
+      await challengesApi.decline(challengeId);
+      setItems(prev => prev.map(n =>
+        n.payload?.challengeId?.toString() === challengeId.toString()
+          ? { ...n, seenAt: n.seenAt ?? new Date().toISOString() }
+          : n,
+      ));
+    } catch (err) {
+      alert(err?.response?.data?.message ?? 'Failed to decline challenge');
+    }
+  }, []);
 
   if (!user) return null;
 
@@ -101,7 +257,7 @@ export default function NotificationBell() {
                 <div
                   key={notif._id}
                   className={cn(
-                    'px-4 py-3 cursor-pointer hover:bg-bg-hover transition-colors border-b border-border-cell last:border-0',
+                    'relative px-4 py-3 cursor-pointer hover:bg-bg-hover transition-colors border-b border-border-cell last:border-0 group',
                     !notif.seenAt && 'bg-accent/[.04]',
                   )}
                   onClick={() => handleItemClick(notif)}
@@ -109,13 +265,20 @@ export default function NotificationBell() {
                   tabIndex={0}
                   onKeyDown={e => e.key === 'Enter' && handleItemClick(notif)}
                 >
-                  <p className="text-[.82rem] text-text-primary leading-snug">
-                    <span className="font-medium">@{notif.payload.fromUsername}</span>
-                    {' '}finished today's puzzle in{' '}
-                    <span className="font-mono text-accent">{fmtTime(notif.payload.timeSeconds)}</span>
-                    {notif.payload.hintsUsed > 0 && ' (with hints)'}
-                    {' '}— can you beat it?
-                  </p>
+                  <button
+                    className="absolute top-2 right-2 text-text-dim hover:text-text-primary transition-colors opacity-0 group-hover:opacity-100 p-[2px]"
+                    onClick={e => handleDismiss(e, notif)}
+                    aria-label="Dismiss notification"
+                  >
+                    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                      <line x1="1" y1="1" x2="9" y2="9" /><line x1="9" y1="1" x2="1" y2="9" />
+                    </svg>
+                  </button>
+                  <NotifText
+                    notif={notif}
+                    onAccept={handleAccept}
+                    onDecline={handleDecline}
+                  />
                   <p className="text-[.68rem] text-text-muted mt-[3px]">{relativeTime(notif.createdAt)}</p>
                 </div>
               ))

--- a/src/components/ProfileDrawer.jsx
+++ b/src/components/ProfileDrawer.jsx
@@ -1,10 +1,14 @@
-import { useEffect } from 'react';
-import { useProfile } from '../hooks/useProfile.js';
-import StatsCard from './StatsCard.jsx';
-import { cn } from '../lib/cn.js';
+import { useState, useEffect } from 'react';
+import { useProfile }      from '../hooks/useProfile.js';
+import { useAuth }         from '../context/AuthContext.jsx';
+import StatsCard           from './StatsCard.jsx';
+import ChallengeModal      from './ChallengeModal.jsx';
+import ChallengeH2H        from './ChallengeH2H.jsx';
+import { cn }              from '../lib/cn.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
+// Local fmtTime — handles null/undefined → '—' (different from shared formatTime.js)
 function fmtTime(sec) {
   if (sec === null || sec === undefined) return '—';
   const m = Math.floor(sec / 60).toString().padStart(2, '0');
@@ -69,7 +73,7 @@ function DrawerSkeleton() {
 
 // ── Profile content ───────────────────────────────────────────────────────
 
-function ProfileContent({ profile }) {
+function ProfileContent({ profile, myId, onChallenge, showH2H, onToggleH2H }) {
   const { stats } = profile;
 
   // Total completions across all difficulties for proportional bar
@@ -80,8 +84,10 @@ function ProfileContent({ profile }) {
     stats.byDifficulty.hard.completed,
   );
 
+  const isOtherUser = myId && myId !== profile.userId?.toString();
+
   return (
-    <div className="flex flex-col gap-6 p-6 overflow-y-auto">
+    <div className="flex flex-col gap-6 p-6 overflow-y-auto h-full">
       {/* Header */}
       <div className="flex items-center gap-4">
         <div className={cn(
@@ -106,9 +112,9 @@ function ProfileContent({ profile }) {
 
       {/* 3 highlight cards */}
       <div className="flex gap-3">
-        <StatsCard label="Solved"        value={stats.totalCompleted} />
-        <StatsCard label="Streak"        value={stats.currentStreak}  sub={`best ${stats.longestStreak}`} />
-        <StatsCard label="Avg hints"     value={stats.averageHintsPerGame.toFixed(1)} />
+        <StatsCard label="Solved"    value={stats.totalCompleted} />
+        <StatsCard label="Streak"    value={stats.currentStreak}  sub={`best ${stats.longestStreak}`} />
+        <StatsCard label="Avg hints" value={stats.averageHintsPerGame.toFixed(1)} />
       </div>
 
       {/* Difficulty breakdown */}
@@ -151,6 +157,36 @@ function ProfileContent({ profile }) {
           })}
         </div>
       </div>
+
+      {/* Challenge button — only shown to other users */}
+      {isOtherUser && (
+        <button
+          className="ctrl-btn ctrl-btn-accent w-full justify-center text-[.82rem] py-[.45rem]"
+          onClick={onChallenge}
+        >
+          Challenge {profile.firstName}
+        </button>
+      )}
+
+      {/* H2H section — only shown to other users */}
+      {isOtherUser && (
+        <div>
+          <button
+            className="flex items-center gap-2 text-[.7rem] text-text-dim uppercase tracking-[.07em] mb-3 w-full hover:text-text-muted transition-colors"
+            onClick={onToggleH2H}
+          >
+            Head to Head
+            <span className="ml-auto">{showH2H ? '▴' : '▾'}</span>
+          </button>
+          {showH2H && (
+            <ChallengeH2H
+              opponentUserId={profile.userId?.toString()}
+              opponentUser={profile}
+              myId={myId}
+            />
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -160,10 +196,19 @@ function ProfileContent({ profile }) {
 export default function ProfileDrawer({ username, onClose }) {
   const open = Boolean(username);
   const { profile, loading, error, fetchProfile } = useProfile();
+  const { user } = useAuth();
+  const [showChallengeModal, setShowChallengeModal] = useState(false);
+  const [toast, setToast]   = useState(null);
+  const [showH2H, setShowH2H] = useState(false);
 
   useEffect(() => {
     if (username) fetchProfile(username);
   }, [username, fetchProfile]);
+
+  // Reset H2H panel when drawer switches to a different user
+  useEffect(() => {
+    setShowH2H(false);
+  }, [username]);
 
   // Lock body scroll while open
   useEffect(() => {
@@ -171,6 +216,11 @@ export default function ProfileDrawer({ username, onClose }) {
     else       document.body.style.overflow = '';
     return () => { document.body.style.overflow = ''; };
   }, [open]);
+
+  const handleChallengeSent = (message) => {
+    setToast(message);
+    setTimeout(() => setToast(null), 3000);
+  };
 
   return (
     <>
@@ -187,7 +237,7 @@ export default function ProfileDrawer({ username, onClose }) {
       {/* Drawer panel */}
       <div
         className={cn(
-          'fixed top-0 right-0 z-40 h-full w-full max-w-[480px]',
+          'fixed top-0 right-0 z-40 h-full w-full max-w-[600px]',
           'bg-bg-surface border-l border-border-cell shadow-2xl',
           'flex flex-col',
           'transition-transform duration-300 ease-in-out',
@@ -219,9 +269,37 @@ export default function ProfileDrawer({ username, onClose }) {
               <p className="text-text-muted text-sm text-center">{error}</p>
             </div>
           )}
-          {!loading && !error && profile && <ProfileContent profile={profile} />}
+          {!loading && !error && profile && (
+            <ProfileContent
+              profile={profile}
+              myId={user?.id}
+              onChallenge={() => setShowChallengeModal(true)}
+              showH2H={showH2H}
+              onToggleH2H={() => setShowH2H(v => !v)}
+            />
+          )}
         </div>
       </div>
+
+      {/* Toast */}
+      {toast && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 bg-bg-surface border border-accent-dim text-accent text-sm px-5 py-2 rounded-full shadow-lg animate-fade-in">
+          {toast}
+        </div>
+      )}
+
+      {/* Challenge modal */}
+      {showChallengeModal && profile && (
+        <ChallengeModal
+          toUser={{
+            userId:    profile.userId?.toString(),
+            username:  profile.username,
+            firstName: profile.firstName,
+          }}
+          onClose={() => setShowChallengeModal(false)}
+          onSent={handleChallengeSent}
+        />
+      )}
     </>
   );
 }

--- a/src/hooks/useChallengePuzzle.js
+++ b/src/hooks/useChallengePuzzle.js
@@ -1,0 +1,118 @@
+import { useState, useEffect, useRef } from 'react';
+import { useTimer }       from './useTimer.js';
+import { useSudoku }      from './useSudoku.js';
+import { challengesApi }  from '../api/challenges.js';
+import { useAuth }        from '../context/AuthContext.jsx';
+
+const storageKey = (id) => `challenge_progress_${id}`;
+
+function saveProgress(id, grid, notes, timerSeconds, hintsUsed) {
+  try {
+    localStorage.setItem(storageKey(id), JSON.stringify({ grid, notes, timerSeconds, hintsUsed }));
+  } catch { /* quota exceeded — ignore */ }
+}
+
+function loadProgress(id) {
+  try {
+    const raw = localStorage.getItem(storageKey(id));
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function clearProgress(id) {
+  try { localStorage.removeItem(storageKey(id)); } catch { /* ignore */ }
+}
+
+export function useChallengePuzzle(challengeId) {
+  const [challenge, setChallenge]       = useState(null);
+  const [loading, setLoading]           = useState(true);
+  const [error, setError]               = useState(null);
+  const [submitResult, setSubmitResult] = useState(null);
+  const [submitError, setSubmitError]   = useState(null);
+  const [isViewOnly, setIsViewOnly]     = useState(false);
+  const submitted = useRef(false);
+  const loaded    = useRef(false);   // guard so the save effect doesn't fire before first load
+  const { user } = useAuth();
+
+  const timer  = useTimer();
+  const sudoku = useSudoku(timer.start, timer.stop, timer.reset);
+
+  useEffect(() => {
+    if (!challengeId) return;
+    challengesApi.get(challengeId)
+      .then(data => {
+        const ch     = data.challenge;
+        const puzzle = ch.puzzle.split('').map(Number);
+        const myId   = user?.id;
+        const myResult = ch.results?.find(
+          r => r.userId?.toString() === myId || r.userId === myId,
+        );
+
+        setChallenge(ch);
+        submitted.current = Boolean(myResult); // prevent re-submission on view-only load
+
+        if (myResult) {
+          // Already submitted — show read-only view
+          setIsViewOnly(true);
+          sudoku.loadPuzzle(puzzle, ch.difficulty);
+          // Overlay the player's completed grid if it was saved (older submissions may not have it)
+          if (myResult.completedGrid) {
+            const completedGrid = myResult.completedGrid.split('').map(Number);
+            sudoku.restoreProgress(completedGrid, new Array(81).fill(null).map(() => []), myResult.hintsUsed ?? 0);
+          }
+
+          if (ch.status === 'completed') {
+            setSubmitResult({ waiting: false, challenge: ch });
+          } else {
+            // I submitted, waiting for opponent
+            setSubmitResult({ waiting: true });
+          }
+        } else {
+          // Fresh attempt — restore any saved in-progress state
+          sudoku.loadPuzzle(puzzle, ch.difficulty);
+          const saved = loadProgress(challengeId);
+          if (saved) {
+            sudoku.restoreProgress(saved.grid, saved.notes, saved.hintsUsed ?? 0);
+            timer.resume(saved.timerSeconds ?? 0);
+          }
+          loaded.current = true;
+        }
+      })
+      .catch(() => setError('Failed to load challenge'))
+      .finally(() => setLoading(false));
+  }, [challengeId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Persist progress to localStorage on every grid/notes/timer change
+  useEffect(() => {
+    if (!loaded.current || isViewOnly || submitted.current || !challengeId) return;
+    saveProgress(challengeId, sudoku.grid, sudoku.notes, timer.seconds, sudoku.hintsUsed);
+  }, [sudoku.grid, sudoku.notes, timer.seconds, sudoku.hintsUsed]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Submit when puzzle is solved
+  useEffect(() => {
+    if (!sudoku.won || submitted.current || !challenge) return;
+    submitted.current = true;
+    clearProgress(challengeId);
+
+    challengesApi.submit(challengeId, {
+      timeElapsed:   timer.seconds,
+      hintsUsed:     sudoku.hintsUsed,
+      completedGrid: sudoku.grid.join(''),
+    })
+      .then(data => setSubmitResult(data))
+      .catch(err => setSubmitError(err?.response?.data?.message ?? 'Submission failed'));
+  }, [sudoku.won]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return {
+    loading, error, challenge,
+    ...sudoku,
+    timer,
+    submitResult, submitError,
+    isViewOnly,
+    isMyResult: challenge?.results?.find(
+      r => r.userId?.toString() === user?.id || r.userId === user?.id,
+    ),
+  };
+}

--- a/src/hooks/useSudoku.js
+++ b/src/hooks/useSudoku.js
@@ -73,6 +73,14 @@ export function useSudoku(onTimerStart, onTimerStop, onTimerReset) {
     onTimerReset();
   }, [onTimerReset]);
 
+  // ── Restore saved progress (challenge resume) ───────────────
+
+  const restoreProgress = useCallback((savedGrid, savedNotes, savedHintsUsed = 0) => {
+    setGrid([...savedGrid]);
+    setNotes(savedNotes.map(n => [...n]));
+    setHintsUsed(savedHintsUsed);
+  }, []);
+
   // ── Helpers ─────────────────────────────────────────────────
 
   const pushUndo = useCallback(() => {
@@ -236,7 +244,7 @@ export function useSudoku(onTimerStart, onTimerStop, onTimerReset) {
     hintResult, clearHint,
     notes, notesMode, setNotesMode,
     conflicts, highlights, sameValueCells,
-    newGame, loadPuzzle, inputNumber, undo,
+    newGame, loadPuzzle, restoreProgress, inputNumber, undo,
     canUndo: history.length > 0,
     useHint,
     puzzleStr, solutionStr,

--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -22,6 +22,10 @@ export function useTimer() {
     setSeconds(0);
   }, []);
 
+  const resume = useCallback((secs) => {
+    setSeconds(secs);
+  }, []);
+
   useEffect(() => {
     if (running) {
       intervalRef.current = setInterval(() => {
@@ -39,5 +43,5 @@ export function useTimer() {
     return `${m}:${s}`;
   })();
 
-  return { seconds, formatted, running, start, stop, reset };
+  return { seconds, formatted, running, start, stop, reset, resume };
 }

--- a/src/pages/ChallengePage.jsx
+++ b/src/pages/ChallengePage.jsx
@@ -1,0 +1,258 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useAuth }               from '../context/AuthContext.jsx';
+import { useChallengePuzzle }    from '../hooks/useChallengePuzzle.js';
+import Board                     from '../components/Board.jsx';
+import HintPanel                 from '../components/HintPanel.jsx';
+import HintExplanation           from '../components/HintExplanation.jsx';
+import NumberPad                 from '../components/NumberPad.jsx';
+import ChallengeResultCard       from '../components/ChallengeResultCard.jsx';
+import { challengesApi }         from '../api/challenges.js';
+import { fmtTime }               from '../lib/formatTime.js';
+import { cn }                    from '../lib/cn.js';
+
+const DIFF_COLORS = { easy: 'text-green-400', medium: 'text-yellow-400', hard: 'text-red-400' };
+
+function daysUntil(dateStr) {
+  const diff = new Date(dateStr) - Date.now();
+  if (diff <= 0) return 'expired';
+  const days = Math.ceil(diff / 86400000);
+  return `${days} day${days !== 1 ? 's' : ''} left`;
+}
+
+function ChallengeBanner({ challenge, myId }) {
+  if (!challenge) return null;
+  const isRecipient = (challenge.toUserId?._id ?? challenge.toUserId)?.toString() === myId;
+  const other       = isRecipient ? challenge.fromUserId : challenge.toUserId;
+  const otherName   = other?.username ? `@${other.username}` : 'Opponent';
+
+  return (
+    <div className="flex items-center gap-3 w-full max-w-[min(540px,94vw)] bg-bg-surface border border-border-cell rounded-lg px-3 py-[.45rem] text-[.78rem]">
+      <span className="text-text-muted">
+        {isRecipient ? `Challenge from ${otherName}` : `You challenged ${otherName}`}
+      </span>
+      <span className="text-text-dim">·</span>
+      <span className={cn('capitalize font-medium', DIFF_COLORS[challenge.difficulty])}>
+        {challenge.difficulty}
+      </span>
+      {challenge.expiresAt && (
+        <>
+          <span className="text-text-dim">·</span>
+          <span className="text-text-muted">{daysUntil(challenge.expiresAt)}</span>
+        </>
+      )}
+    </div>
+  );
+}
+
+function WaitingCard({ timerFormatted, opponentName, challengeId, onHome }) {
+  const [nudged, setNudged]   = useState(false);
+  const [nudging, setNudging] = useState(false);
+
+  const handleNudge = async () => {
+    setNudging(true);
+    try {
+      await challengesApi.nudge(challengeId);
+      setNudged(true);
+    } catch { /* ignore */ } finally {
+      setNudging(false);
+    }
+  };
+
+  return (
+    <div className="bg-bg-surface border border-accent-dim rounded-xl px-7 py-6 max-w-[420px] w-full text-center shadow-[0_0_0_1px_rgba(201,169,110,.15),0_8px_32px_rgba(0,0,0,.4)]">
+      <div className="text-[1.3rem] tracking-[.4em] text-accent mb-2 animate-sparkle" aria-hidden="true">✦ ✧ ✦</div>
+      <h2 className="font-title text-[1.6rem] font-bold text-accent mb-1">Puzzle complete!</h2>
+      <p className="text-text-muted text-[.83rem] mb-4">
+        Your time: <span className="font-mono text-text-primary text-[1rem]">{timerFormatted}</span>
+      </p>
+      <p className="text-text-muted text-[.8rem] mb-5">
+        Waiting for <span className="text-text-primary font-medium">{opponentName}</span> to finish their attempt…
+      </p>
+      <div className="flex flex-col gap-2">
+        <button
+          className="ctrl-btn ctrl-btn-accent w-full justify-center text-[.85rem] py-[.5rem] disabled:opacity-50"
+          onClick={handleNudge}
+          disabled={nudged || nudging}
+        >
+          {nudged ? 'Nudge sent!' : nudging ? 'Sending…' : `Nudge ${opponentName}`}
+        </button>
+        <button
+          className="ctrl-btn w-full justify-center text-[.82rem] py-[.45rem]"
+          onClick={onHome}
+        >
+          Back to Home
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function ChallengePage() {
+  const { id }   = useParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const cp       = useChallengePuzzle(id);
+
+  if (cp.loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[calc(100dvh-2.75rem)]">
+        <span className="text-text-muted text-sm">Loading challenge…</span>
+      </div>
+    );
+  }
+
+  if (cp.error) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[calc(100dvh-2.75rem)] gap-4">
+        <p className="text-text-muted text-sm">{cp.error}</p>
+        <button className="ctrl-btn" onClick={() => navigate('/friends')}>Back to Friends</button>
+      </div>
+    );
+  }
+
+  const bothSubmitted = cp.submitResult && !cp.submitResult.waiting;
+  const challenge     = cp.challenge;
+  const myId          = user?.id;
+
+  const opponentUser = challenge
+    ? ((challenge.fromUserId?._id ?? challenge.fromUserId)?.toString() === myId
+        ? challenge.toUserId
+        : challenge.fromUserId)
+    : null;
+
+  const completeChallenge = bothSubmitted && cp.submitResult?.challenge
+    ? cp.submitResult.challenge
+    : null;
+
+  const handleChallengeAgain = async () => {
+    if (!opponentUser || !challenge) return;
+    try {
+      const res = await challengesApi.send(
+        opponentUser._id ?? opponentUser,
+        challenge.difficulty,
+      );
+      navigate(`/challenges/${res.challenge._id}`);
+    } catch { /* ignore — may have open challenge */ }
+  };
+
+  return (
+    <div className="flex flex-col min-h-[calc(100dvh-2.75rem)] px-4 pb-8">
+      <header className="text-center pt-6 pb-3">
+        <h1 className="font-title text-[clamp(1.8rem,4vw,2.8rem)] font-bold text-accent tracking-[.04em] [text-shadow:0_0_40px_rgba(201,169,110,.35)]">
+          Challenge
+        </h1>
+      </header>
+
+      <main className="flex flex-col items-center gap-4 w-full max-w-[900px] mx-auto">
+        <ChallengeBanner challenge={challenge} myId={myId} />
+
+        {/* Submit error */}
+        {cp.submitError && (
+          <div className="flex items-center gap-2 text-[.78rem] text-yellow-400/80 bg-yellow-400/5 border border-yellow-400/20 rounded-lg px-3 py-[.4rem] w-full max-w-[min(540px,94vw)]">
+            Could not save result: {cp.submitError}
+          </div>
+        )}
+
+        {/* Waiting card — after current user submits, before opponent does */}
+        {cp.submitResult?.waiting && (
+          <WaitingCard
+            timerFormatted={cp.timer.formatted}
+            opponentName={opponentUser?.firstName ?? 'opponent'}
+            challengeId={id}
+            onHome={() => navigate('/')}
+          />
+        )}
+
+        {/* Result card — both players submitted */}
+        {completeChallenge && (
+          <ChallengeResultCard
+            challenge={completeChallenge}
+            myId={myId}
+            onChallengeAgain={handleChallengeAgain}
+            onViewH2H={opponentUser ? () => navigate(`/profile/${opponentUser.username}`) : null}
+          />
+        )}
+
+        {/* Controls: timer + notes + undo — only while in-progress */}
+        {!cp.submitResult && !cp.isViewOnly && (
+          <div className="flex items-center justify-between w-full max-w-[min(540px,94vw)] gap-3">
+            <div className="w-[80px]" />
+            <div className={cn(
+              'font-mono text-[1.35rem] font-medium tracking-[.08em] min-w-[5ch] text-center transition-colors duration-[200ms]',
+              cp.won ? 'text-accent [text-shadow:0_0_12px_rgba(201,169,110,.35)]' : 'text-text-muted',
+            )}>
+              {cp.timer.formatted}
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                className={cn('ctrl-btn', cp.notesMode && 'ctrl-btn-accent')}
+                onClick={() => cp.setNotesMode(m => !m)}
+                title="Toggle notes mode"
+                aria-label="Toggle notes mode"
+                aria-pressed={cp.notesMode}
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/>
+                  <path d="m15 5 4 4"/>
+                </svg>
+                Notes
+              </button>
+              <button
+                className="ctrl-btn"
+                onClick={cp.undo}
+                disabled={!cp.canUndo}
+                title="Undo (Ctrl+Z)"
+                aria-label="Undo last move"
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <polyline points="9 14 4 9 9 4"/>
+                  <path d="M20 20v-7a4 4 0 0 0-4-4H4"/>
+                </svg>
+                Undo
+              </button>
+            </div>
+          </div>
+        )}
+
+        <div className="flex flex-row items-start gap-6 w-full justify-center max-[700px]:flex-col max-[700px]:items-center">
+          <div className="flex flex-col items-center gap-3">
+            <Board
+              grid={cp.grid}
+              given={cp.given}
+              selected={!cp.isViewOnly ? cp.selected : null}
+              conflicts={cp.conflicts}
+              highlights={cp.highlights}
+              sameValueCells={cp.sameValueCells}
+              hintResult={cp.hintResult}
+              notes={cp.notes}
+              onSelect={!cp.isViewOnly ? cp.setSelected : undefined}
+            />
+            {!cp.isViewOnly && (
+              <>
+                <HintExplanation hintResult={cp.hintResult} onDismiss={cp.clearHint} />
+                <NumberPad
+                  onInput={cp.inputNumber}
+                  selected={cp.selected}
+                  given={cp.given}
+                  notesMode={cp.notesMode}
+                />
+              </>
+            )}
+          </div>
+          {!cp.isViewOnly && (
+            <aside className="w-[220px] flex-shrink-0 max-[700px]:w-[min(540px,94vw)]">
+              <HintPanel
+                hintType={cp.hintType}
+                onHintType={cp.setHintType}
+                onUseHint={cp.useHint}
+                hintsUsed={cp.hintsUsed}
+                won={cp.won}
+              />
+            </aside>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/pages/FriendsPage.jsx
+++ b/src/pages/FriendsPage.jsx
@@ -1,9 +1,12 @@
-import { useState } from 'react';
-import { useFriends } from '../hooks/useFriends.js';
-import ProfileDrawer from '../components/ProfileDrawer.jsx';
-import { cn } from '../lib/cn.js';
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate }   from 'react-router-dom';
+import { useFriends }    from '../hooks/useFriends.js';
+import { useAuth }       from '../context/AuthContext.jsx';
+import { challengesApi } from '../api/challenges.js';
+import ProfileDrawer     from '../components/ProfileDrawer.jsx';
+import { cn }            from '../lib/cn.js';
 
-const TABS = ['My Friends', 'Requests', 'Find Friends'];
+const TABS = ['My Friends', 'Requests', 'Find Friends', 'Challenges'];
 
 function UserRow({ user, actions, onNameClick }) {
   return (
@@ -25,12 +28,203 @@ function UserRow({ user, actions, onNameClick }) {
   );
 }
 
+const DIFF_COLORS = { easy: 'text-green-400', medium: 'text-yellow-400', hard: 'text-red-400' };
+
+function ChallengeRow({ challenge, myId, onPlay, onViewBoard, onAccept, onDecline, onCancel }) {
+  const isFrom     = challenge.fromUserId?._id?.toString() === myId || challenge.fromUserId?.toString() === myId;
+  const other      = isFrom ? challenge.toUserId : challenge.fromUserId;
+  const otherName  = other?.username ? `@${other.username}` : 'Unknown';
+  const diffColor  = DIFF_COLORS[challenge.difficulty] ?? 'text-text-muted';
+
+  const expiresInDays = challenge.expiresAt
+    ? Math.ceil((new Date(challenge.expiresAt) - Date.now()) / 86400000)
+    : null;
+
+  return (
+    <div className="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-bg-hover transition-colors gap-2">
+      <div className="flex flex-col min-w-0">
+        <span className="text-sm text-text-primary font-medium truncate">
+          {isFrom ? `You challenged ${otherName}` : `Challenge from ${otherName}`}
+        </span>
+        <div className="flex items-center gap-2 mt-[2px]">
+          <span className={cn('text-[.72rem] capitalize font-medium', diffColor)}>
+            {challenge.difficulty}
+          </span>
+          {expiresInDays !== null && expiresInDays > 0 && (
+            <span className="text-[.68rem] text-text-dim">· {expiresInDays}d left</span>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        {onViewBoard && (
+          <button className="ctrl-btn text-[.72rem] py-1 px-2" onClick={onViewBoard}>
+            View Board
+          </button>
+        )}
+        {onPlay && (
+          <button className="ctrl-btn ctrl-btn-accent text-[.72rem] py-1 px-2" onClick={onPlay}>
+            Play
+          </button>
+        )}
+        {onAccept && (
+          <button className="ctrl-btn ctrl-btn-accent text-[.72rem] py-1 px-2" onClick={onAccept}>
+            Accept
+          </button>
+        )}
+        {onDecline && (
+          <button className="ctrl-btn text-[.72rem] py-1 px-2" onClick={onDecline}>
+            Decline
+          </button>
+        )}
+        {onCancel && (
+          <button className="ctrl-btn text-[.72rem] py-1 px-2" onClick={onCancel}>
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ChallengesTab({ myId }) {
+  const navigate  = useNavigate();
+  const [data, setData]       = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError]     = useState(null);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    challengesApi.getAll()
+      .then(setData)
+      .catch(() => setError('Failed to load challenges'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleAccept = async (id) => {
+    try {
+      await challengesApi.accept(id);
+      navigate(`/challenges/${id}`);
+    } catch (err) {
+      alert(err?.response?.data?.message ?? 'Failed to accept challenge');
+    }
+  };
+
+  const handleDecline = async (id) => {
+    try {
+      await challengesApi.decline(id);
+      load();
+    } catch (err) {
+      alert(err?.response?.data?.message ?? 'Failed to decline challenge');
+    }
+  };
+
+  const handleCancel = async (id) => {
+    try {
+      await challengesApi.cancel(id);
+      load();
+    } catch (err) {
+      alert(err?.response?.data?.message ?? 'Failed to cancel challenge');
+    }
+  };
+
+  if (loading) {
+    return <div className="flex justify-center py-8"><span className="text-text-muted text-sm">Loading…</span></div>;
+  }
+
+  if (error) {
+    return <p className="text-text-muted text-sm text-center py-8">{error}</p>;
+  }
+
+  const { received = [], sent = [], active = [], completed = [] } = data ?? {};
+  const isEmpty = received.length + sent.length + active.length + completed.length === 0;
+
+  if (isEmpty) {
+    return (
+      <p className="text-text-muted text-sm text-center py-8">
+        No challenges yet. Open a friend's profile to send one!
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      {received.length > 0 && (
+        <div>
+          <h3 className="text-[.75rem] text-text-muted uppercase tracking-widest mb-2">Received</h3>
+          <div className="flex flex-col gap-1">
+            {received.map(c => (
+              <ChallengeRow
+                key={c._id}
+                challenge={c}
+                myId={myId}
+                onAccept={() => handleAccept(c._id)}
+                onDecline={() => handleDecline(c._id)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {active.length > 0 && (
+        <div>
+          <h3 className="text-[.75rem] text-text-muted uppercase tracking-widest mb-2">In Progress</h3>
+          <div className="flex flex-col gap-1">
+            {active.map(c => (
+              <ChallengeRow
+                key={c._id}
+                challenge={c}
+                myId={myId}
+                onPlay={() => navigate(`/challenges/${c._id}`)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {sent.length > 0 && (
+        <div>
+          <h3 className="text-[.75rem] text-text-muted uppercase tracking-widest mb-2">Sent</h3>
+          <div className="flex flex-col gap-1">
+            {sent.map(c => (
+              <ChallengeRow
+                key={c._id}
+                challenge={c}
+                myId={myId}
+                onCancel={() => handleCancel(c._id)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {completed.length > 0 && (
+        <div>
+          <h3 className="text-[.75rem] text-text-muted uppercase tracking-widest mb-2">Completed</h3>
+          <div className="flex flex-col gap-1">
+            {completed.map(c => (
+              <ChallengeRow
+                key={c._id}
+                challenge={c}
+                myId={myId}
+                onViewBoard={() => navigate(`/challenges/${c._id}`)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function FriendsPage() {
-  const [tab, setTab] = useState(0);
-  const [query, setQuery] = useState('');
+  const [tab, setTab]       = useState(0);
+  const [query, setQuery]   = useState('');
   const [confirmRemove, setConfirmRemove] = useState(null);
   const [drawerUsername, setDrawerUsername] = useState(null);
   const f = useFriends();
+  const { user } = useAuth();
 
   const handleSearch = (e) => {
     const val = e.target.value;
@@ -233,6 +427,11 @@ export default function FriendsPage() {
               </div>
             )}
           </div>
+        )}
+
+        {/* Challenges */}
+        {tab === 3 && (
+          <ChallengesTab myId={user?.id} />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Players can challenge a friend to the same puzzle across any difficulty
- Full challenge lifecycle: send, accept, decline, cancel, submit, nudge opponent
- Mid-game progress (grid, notes, timer) persisted to localStorage and restored on revisit
- Completed challenges show a read-only board via "View Board" from the friends list
- H2H stats panel in profile drawer showing win/loss record and insights
- All challenge events (received, accepted, declined, completed, nudge) surface as dismissible notifications in the bell

## What's included

**Backend**
- `Challenge` model with embedded results per player, solution hidden with `select: false`, 7-day expiry
- 9 routes: send, get all, get one, accept, decline, cancel, submit, H2H stats, nudge
- Opponent's time hidden from response until the current user has submitted
- Nudge replaces any prior nudge notification so re-nudging is allowed
- `dismissNotification` endpoint — permanently deletes a notification

**Frontend**
- `useChallengePuzzle` hook: wraps `useSudoku` + `useTimer`, saves progress to localStorage on every move, restores on revisit, view-only mode when already submitted
- `ChallengePage`: in-progress board with notes/undo, WaitingCard with nudge button after completing, result card once both have submitted
- `ChallengeModal`, `ChallengeResultCard`, `ChallengeH2H` components
- Friends page Challenges tab: Received / Sent / In Progress / Completed sections
- Profile drawer: Challenge button, collapsible H2H section, scroll fix

## Test plan

- [x] Send a challenge from a user's profile drawer
- [x] Accept via notification bell or Friends → Challenges tab
- [x] Play partway through, navigate away, return — progress and notes restored
- [x] Complete puzzle — WaitingCard shows with correct time and nudge button
- [x] Nudge opponent — they receive a notification; nudge button shows "Nudge sent!"
- [x] Both complete — result card shows winner, time diff, Challenge Again / View H2H
- [x] View Board on a completed challenge shows read-only board, no controls
- [x] Dismiss a notification — removed immediately, badge decrements
- [x] H2H panel in profile drawer shows stats and insights after 3+ games
EOF
)"